### PR TITLE
CI Cleanup and Parallel Testing

### DIFF
--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           source triton_bench/bin/activate
           pip freeze
-          pytest -s kernels
+          pytest -n 4 -s kernels
       
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   kernel-bench:
     runs-on: amdgpu-mi250-x86-64
+    env:
+      KERNEL_VENV_DIR: ${{ github.workspace }}/triton_bench
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -28,15 +30,15 @@ jobs:
 
       - name: Setup Triton Python Venv
         run: |
-          python3.11 -m venv triton_bench
-          source triton_bench/bin/activate
+          python3.11 -m venv ${KERNEL_VENV_DIR}
+          source ${KERNEL_VENV_DIR}/bin/activate
           pip install --upgrade pip
           pip install --pre pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.2
           pip install -r requirements.txt
 
       - name: Run Kernel Benchmarking
         run: |
-          source triton_bench/bin/activate
+          source ${KERNEL_VENV_DIR}/bin/activate
           pip freeze
           pytest -n 4 -s kernels
       

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -21,8 +21,8 @@ jobs:
     env:
       KERNEL_VENV_DIR: ${{ github.workspace }}/triton_bench
     steps:
-      - name : Print body of PR
-        run: echo The body of your PR is ${{ github.event.pull_request.body }}
+      - name : Set Test File
+        run: python3.11 ci-tools/parse.py --test ${{ github.event.pull_request.body }}
 
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         run: |
           source ${KERNEL_VENV_DIR}/bin/activate
           pip freeze
-          pytest kernels -s -n 4
+          pytest kernels/${TEST_FILE} -s -n 4
       
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -37,7 +37,7 @@ jobs:
           python3.11 -m venv ${KERNEL_VENV_DIR}
           source ${KERNEL_VENV_DIR}/bin/activate
           pip install --upgrade pip
-          pip install --pre pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+          pip install --pre pytorch-triton-rocm==3.1.0+cf34004b8a torch==2.6.0.dev20241023+rocm6.2 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
           pip install pytest-xdist
           pip install -r requirements.txt
 

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -30,7 +30,9 @@ jobs:
           python-version: "3.11"
 
       - name : Set Test File
-        run: python3.11 ci-tools/parse.py --test "${{ github.event.pull_request.body }}"
+        run: |
+          python3.11 ci-tools/parse.py --test "${{ github.event.pull_request.body }}"
+          echo "TEST_FILE=$TEST_FILE" >> $GITHUB_ENV
 
       - name: Setup Triton Python Venv
         run: |

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -19,7 +19,7 @@ jobs:
   kernel-bench:
     runs-on: amdgpu-mi250-x86-64
     env:
-      KERNEL_VENV_DIR: ${{ github.workspace }}/triton_bench
+      KERNEL_VENV_DIR: /groups/aig_sharks/triton_bench
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -1,6 +1,7 @@
 name: Triton Kernel Benchmarking
 on:
   pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
   schedule:
   # Runs at 12:00 PM UTC, which is 5:00 AM PST
@@ -20,6 +21,9 @@ jobs:
     env:
       KERNEL_VENV_DIR: ${{ github.workspace }}/triton_bench
     steps:
+      - name : Print body of PR
+        run: echo The body of your PR is ${{ github.event.pull_request.body }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           source ${KERNEL_VENV_DIR}/bin/activate
           pip freeze
-          pytest -n 4 -s kernels
+          pytest -s kernels --numprocesses 4
       
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -11,7 +11,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows. test
+  # different workflows.
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -22,7 +22,7 @@ jobs:
       KERNEL_VENV_DIR: ${{ github.workspace }}/triton_bench
     steps:
       - name : Set Test File
-        run: python3.11 ci-tools/parse.py --test ${{ github.event.pull_request.body }}
+        run: python3.11 ci-tools/parse.py --test "${{ github.event.pull_request.body }}"
 
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -21,9 +21,6 @@ jobs:
     env:
       KERNEL_VENV_DIR: ${{ github.workspace }}/triton_bench
     steps:
-      - name : Set Test File
-        run: python3.11 ci-tools/parse.py --test "${{ github.event.pull_request.body }}"
-
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -31,6 +28,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name : Set Test File
+        run: python3.11 ci-tools/parse.py --test "${{ github.event.pull_request.body }}"
 
       - name: Setup Triton Python Venv
         run: |

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -34,13 +34,14 @@ jobs:
           source ${KERNEL_VENV_DIR}/bin/activate
           pip install --upgrade pip
           pip install --pre pytorch-triton-rocm torch --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+          pip install pytest-xdist
           pip install -r requirements.txt
 
       - name: Run Kernel Benchmarking
         run: |
           source ${KERNEL_VENV_DIR}/bin/activate
           pip freeze
-          pytest -s kernels --numprocesses 4
+          pytest kernels -s -n 4
       
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -11,7 +11,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
+  # different workflows. test
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 

--- a/.github/workflows/kernel-bench.yml
+++ b/.github/workflows/kernel-bench.yml
@@ -32,7 +32,6 @@ jobs:
       - name : Set Test File
         run: |
           python3.11 ci-tools/parse.py --test "${{ github.event.pull_request.body }}"
-          echo "TEST_FILE=$TEST_FILE" >> $GITHUB_ENV
 
       - name: Setup Triton Python Venv
         run: |
@@ -47,7 +46,7 @@ jobs:
         run: |
           source ${KERNEL_VENV_DIR}/bin/activate
           pip freeze
-          pytest kernels/${TEST_FILE} -s -n 4
+          pytest kernels/${{ env.TEST_FILE }} -s -n 4
       
       - uses: actions/upload-artifact@master
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The main things you need to run your own benchmark
 1. In `kernels/` create a new file that must start with the name `test_`. This is because we use `pytest` to discover your kernel
 2. If you want your benchmark results to persist in a Github Artifact, we recommend using the builtin Triton `benchmark.run(save_path="./perf-artifacts/your_kernel", show_plots=True, print_data=True)`
 3. In your PR, if you don't want to run testing on all the kernels, you can specify a specific kernel you want
-to test by adding a line like the following to your PR description: "ci-exactly: <test-file-name.py>" as seen
+to test by adding a line like the following to your PR description: `ci-exactly: <test-file-name.py>` as seen
 in this PR: [Example](https://github.com/gpu-mode/amd-cluster/pull/3)
 
 Have fun! We intend for this to be a social repo, if you have any other requests for things we could do better please let us know!

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This repo is configured with a custom Github runner donated by AMD. You can queu
 The main things you need to run your own benchmark
 1. In `kernels/` create a new file that must start with the name `test_`. This is because we use `pytest` to discover your kernel
 2. If you want your benchmark results to persist in a Github Artifact, we recommend using the builtin Triton `benchmark.run(save_path="./perf-artifacts/your_kernel", show_plots=True, print_data=True)`
+3. In your PR, if you don't want to run testing on all the kernels, you can specify a specific kernel you want
+to test by adding a line like the following to your PR description: "ci-exactly: <test-file-name.py>" as seen
+in this PR: [Example](https://github.com/gpu-mode/amd-cluster/pull/3)
 
 Have fun! We intend for this to be a social repo, if you have any other requests for things we could do better please let us know!
 

--- a/ci-tools/parse.py
+++ b/ci-tools/parse.py
@@ -3,8 +3,10 @@ import os
 
 def set_env_variable_from_string(input_string):
     if "ci-exactly:" in input_string:
+        env_file = os.getenv('GITHUB_ENV')
         test_name = input_string.split("ci-exactly:")[1].strip()
-        os.environ["TEST_FILE"] = test_name
+        with open(env_file, "a") as myfile:
+            myfile.write(f"TEST_FILE={test_name}")
         print(f'Successfully set TEST_FILE to: {test_name}')
     else:
         print('The PR body does not contain "ci-exactly:" so running all tests')

--- a/ci-tools/parse.py
+++ b/ci-tools/parse.py
@@ -1,0 +1,17 @@
+import argparse
+import os
+
+def set_env_variable_from_string(input_string):
+    if "ci-exactly:" in input_string:
+        test_name = input_string.split("ci-exactly:")[1].strip()
+        os.environ["TEST_FILE"] = test_name
+        print(f'Successfully set TEST_FILE to: {test_name}')
+    else:
+        print('The PR body does not contain "ci-exactly:" so running all tests')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Set TEST_FILE environment variable from PR body")
+    parser.add_argument("--test", required=True, help="PR body containing 'ci-exactly:'")
+
+    args = parser.parse_args()
+    set_env_variable_from_string(args.test)


### PR DESCRIPTION
This commit caches the python environment, runs testing parallelly on multiple gpus, and allows you to specify a certain file that you want to run tests on like in this PR.

ci-exactly: test_dot_product.py